### PR TITLE
feat(validation): allow `ValidationRule`

### DIFF
--- a/src/Contracts/QueryFilter.php
+++ b/src/Contracts/QueryFilter.php
@@ -7,11 +7,12 @@ namespace Sylarele\HttpQueryConfig\Contracts;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Stringable;
 
 /**
  * Interface for both filters and scopes.
  *
- * @phpstan-type ValidationRule array<int, string|\Stringable|Rule>
+ * @phpstan-type ValidationRule array<int, string|Stringable|Rule>
  * @phpstan-type ValidationRules array<string, ValidationRule>
  *
  * @template TModel of Model

--- a/src/Contracts/QueryFilter.php
+++ b/src/Contracts/QueryFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylarele\HttpQueryConfig\Contracts;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule as IlluminateValidationRule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Stringable;
@@ -12,7 +13,7 @@ use Stringable;
 /**
  * Interface for both filters and scopes.
  *
- * @phpstan-type ValidationRule array<int, string|Stringable|Rule>
+ * @phpstan-type ValidationRule array<int, string|Stringable|Rule|IlluminateValidationRule>
  * @phpstan-type ValidationRules array<string, ValidationRule>
  *
  * @template TModel of Model

--- a/src/Query/ScopeArgument.php
+++ b/src/Query/ScopeArgument.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace Sylarele\HttpQueryConfig\Query;
 
 use Closure;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Database\Eloquent\Model;
 use ReflectionNamedType;
 use ReflectionParameter;
-use Stringable;
 use Sylarele\HttpQueryConfig\Contracts\QueryFilter;
 use Sylarele\HttpQueryConfig\Contracts\Transformer;
 
 /**
  * A query scope argument config.
  *
+ * @phpstan-import-type ValidationRule from QueryFilter
  * @phpstan-import-type ValidationRules from QueryFilter
  */
 class ScopeArgument
@@ -80,7 +79,7 @@ class ScopeArgument
     /**
      * Set custom validation rule for this argument.
      *
-     * @param array<int, string|Stringable|Rule> $rules
+     * @param ValidationRule $rules
      */
     public function withValidation(array $rules): static
     {
@@ -92,7 +91,7 @@ class ScopeArgument
     /**
      * Sets custom validation rules for this argument.
      *
-     * @param array<int, string|Stringable|Rule> $rules
+     * @param ValidationRule $rules
      */
     public function addedValidation(string $subKey, array $rules): static
     {


### PR DESCRIPTION
- Allow `Illuminate\Contracts\Validation\ValidationRule` in `ScopeArgument@withValidation`.
- Import phpstan type `ValidationRule` from `QueryFilter` instead of duplicating it

Note : the deprecated contract `Illuminate\Contracts\Validation\Rule` cannot be removed because it is still inherited at least by Laravel's `Illuminate\Validation\Rules\Enum` rule.