### PR TITLE
feat(transformer): allow nested data (on three levels)

### DIFF
--- a/src/Contracts/Transformer.php
+++ b/src/Contracts/Transformer.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Sylarele\HttpQueryConfig\Contracts;
 
+/**
+ * @phpstan-type TransformableData string|array<array-key, string>
+ */
 interface Transformer
 {
     /**
-     * @param string|array<int|string,string>|string $value
+     * @param TransformableData|array<array-key, TransformableData|array<array-key, TransformableData>> $value
      */
     public function transform(array|string $value): mixed;
 }


### PR DESCRIPTION
Change `Sylarele\HttpQueryConfig\Contracts\Transformer@transform` phpdoc to allow up to three levels of nested data.

Note : we must set a nested limit (here three) because phpstan does not allow recursive type declaration:
```
 ------ -------------------------------------------------------------------------------------------------------------------------
  Line   src/Contracts/Transformer.php
 ------ -------------------------------------------------------------------------------------------------------------------------
  10     Circular definition detected in type alias TransformableData.
         🪪  typeAlias.circular
```