### PR TITLE
fix: descriptive error when sub-relation ancestor not registered

### DIFF
--- a/src/Concerns/HttpBuilder.php
+++ b/src/Concerns/HttpBuilder.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use InvalidArgumentException;
+use RuntimeException;
 use Sylarele\HttpQueryConfig\Contracts\QueryResult;
 use Sylarele\HttpQueryConfig\Enums\FilterMode;
 use Sylarele\HttpQueryConfig\Enums\FilterType;
@@ -159,18 +160,26 @@ trait HttpBuilder
         $dotPosition = strrpos($relation->getName(), '.');
 
         if ($dotPosition !== false) {
-            $subRelation = $query
-                ->getConfig()
-                ->getRelationship(
-                    relationship: substr($relation->getName(), 0, $dotPosition),
-                );
+            $parentName = substr($relation->getName(), 0, $dotPosition);
 
-            if ($subRelation instanceof Relationship) {
-                $builder = $this->applyRelationship(
-                    $query,
-                    new RelationshipValue(relationship: $subRelation)
+            $parentRelation = $query
+                ->getConfig()
+                ->getRelationship(relationship: $parentName);
+
+            if (! $parentRelation instanceof Relationship) {
+                throw new RuntimeException(
+                    \sprintf(
+                        'Relation `%s` must be registered before its sub-relation `%s`.',
+                        $parentName,
+                        $relation->getName(),
+                    ),
                 );
             }
+
+            $builder = $this->applyRelationship(
+                $query,
+                new RelationshipValue(relationship: $parentRelation)
+            );
         }
 
         return $builder;

--- a/src/Query/QueryConfig.php
+++ b/src/Query/QueryConfig.php
@@ -307,16 +307,10 @@ class QueryConfig
             return $relationship;
         }
 
-        $foundRelationship = Arr::first(
+        return Arr::first(
             array: $this->relationships,
             callback: static fn (Relationship $r): bool => $r->getName() === $relationship,
         );
-
-        if (! $foundRelationship instanceof Relationship) {
-            throw new RuntimeException('Invalid type for `$foundRelationship`');
-        }
-
-        return $foundRelationship;
     }
 
     /**
@@ -343,7 +337,12 @@ class QueryConfig
         );
 
         if (! $foundRelationship instanceof Relationship) {
-            throw new RuntimeException('Invalid type for `$foundRelationship`');
+            throw new RuntimeException(
+                \sprintf(
+                    'Given relationship named `%s` is not registered on this query type.',
+                    $relationship,
+                ),
+            );
         }
 
         return $foundRelationship;

--- a/tests/Feature/WithQueryTest.php
+++ b/tests/Feature/WithQueryTest.php
@@ -6,6 +6,7 @@ namespace Sylarele\HttpQueryConfig\Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use RuntimeException;
 use Sylarele\HttpQueryConfig\Concerns\HttpBuilder;
 use Sylarele\HttpQueryConfig\Http\QueryRequest;
 use Sylarele\HttpQueryConfig\Query\Query;
@@ -39,6 +40,44 @@ final class WithQueryTest extends TestCase
             ->assertOk()
             ->assertJsonCount(1, 'data.0.bars')
             ->assertJsonPath('data.0.bars.0.name', 'Antoine');
+    }
+
+    public function testShouldLoadNestedRelationWithRegisteredAncestors(): void
+    {
+        $this->createFoos();
+
+        $this
+            ->getJson(
+                route(
+                    'foos.index',
+                    [
+                        'with' => ['bars.foo'],
+                    ]
+                )
+            )
+            ->assertOk()
+            ->assertJsonPath('data.0.bars.0.foo.name', 'Carol');
+    }
+
+    public function testShouldFailWhenAncestorRelationIsNotRegistered(): void
+    {
+        $this->createFoos();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Relation `bars.foo.bars` must be registered before its sub-relation `bars.foo.bars.foo`.'
+        );
+
+        $this->withoutExceptionHandling();
+
+        $this->getJson(
+            route(
+                'foos.index',
+                [
+                    'with' => ['bars.foo.bars.foo'],
+                ]
+            )
+        );
     }
 
     public function testShouldValidatedSort(): void

--- a/workbench/app/Http/Resources/BarResource.php
+++ b/workbench/app/Http/Resources/BarResource.php
@@ -14,7 +14,7 @@ use Workbench\App\Models\Bar;
 class BarResource extends JsonResource
 {
     /**
-     * @return array<string,scalar>
+     * @return array<string,mixed>
      */
     #[Override]
     public function toArray($request): array
@@ -22,6 +22,10 @@ class BarResource extends JsonResource
         return [
             'id' => $this->resource->id,
             'name' => $this->resource->name,
+            'foo' => $this->whenLoaded(
+                'foo',
+                fn (): FooResource => new FooResource($this->resource->foo)
+            ),
         ];
     }
 }

--- a/workbench/app/Queries/FooQuery.php
+++ b/workbench/app/Queries/FooQuery.php
@@ -93,6 +93,8 @@ class FooQuery extends Query
 
         // With
         $config->with('bars');
+        $config->with('bars.foo'); // nested: ancestor `bars` is registered
+        $config->with('bars.foo.bars.foo'); // ancestor `bars.foo.bars` is intentionally NOT registered
 
         $config->only(['name', 'size']);
     }


### PR DESCRIPTION
## Problem
`with('relation.subRelation')` crashes with `RuntimeException: Invalid type for `$foundRelationship`` (QueryConfig.php:316) when the parent relation isn't registered. Registering the parent first hides it. Fixes #41.

## Cause
`getRelationship()` is typed `?Relationship` and its only caller guards with `instanceof Relationship` — both expect `null` on miss. But it **threw** instead of returning null. Walking ancestors of a dotted `with` hit that throw.

## Fix
- `getRelationship()` returns `null` when not found (honors signature).
- `getRelationshipOrFail()` keeps throwing, now with an actionable message.
- `applyRelationship()` walks ancestors and throws a clear error naming the missing ancestor: `Relation \`a.b\` must be registered before its sub-relation \`a.b.c\`.`

## Tests
- nested load with registered ancestors loads the chain
- missing ancestor → descriptive exception

Verified end-to-end on a Laravel 13 + Postgres app, plus full suite (56 tests), PHPStan, cs-fixer, rector, structura all green.