### PR TITLE
feat(filter): validation rules for scalar filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,28 @@ class FooModelQuery extends Query
     }
 }
 ```
+
+## Validation des filtres
+
+Les filtres valident automatiquement leur valeur en fonction de leur `FilterType`.
+Ces règles peuvent être remplacées ou complétées depuis la Query, sans passer par la FormRequest :
+
+```php
+protected function configure(QueryConfig $config): void
+{
+    // Remplace les règles déduites du type, pour `state[value]`
+    $config
+        ->filter('state')
+        ->type(FilterType::String)
+        ->withValidation(['nullable', 'string', new Enum(FooState::class)]);
+
+    // Ajoute des règles sur une sous-clé de la valeur, ici `states[value][*]`
+    $config
+        ->filter('states')
+        ->field('state')
+        ->type(FilterType::Array)
+        ->addedValidation('*', ['required', 'string', new Enum(FooState::class)]);
+}
+```
+
+Les règles des clés `mode` et `not` du filtre restent déduites du `FilterType`.

--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace Sylarele\HttpQueryConfig\Query;
 
 use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 use Override;
-use Stringable;
 use Sylarele\HttpQueryConfig\Contracts\QueryFilter;
 use Sylarele\HttpQueryConfig\Enums\FilterType;
 
 /**
  * Configures a simple query filter, for a single field.
+ *
+ * @phpstan-import-type ValidationRule from QueryFilter
+ * @phpstan-import-type ValidationRules from QueryFilter
  *
  * @template TModel of Model
  * @template TBuilder of Builder
@@ -35,6 +36,9 @@ class Filter implements QueryFilter
 
     /** @var bool whether the filter is a dummy filter (does not affect the query) */
     protected bool $dummy = false;
+
+    /** @var ValidationRules the custom validation rules for the filter */
+    protected array $validation = [];
 
     /**
      * @param TModel $model the model linked to the query
@@ -77,6 +81,32 @@ class Filter implements QueryFilter
     public function default(mixed $value): static
     {
         $this->default = $value;
+
+        return $this;
+    }
+
+    /**
+     * Sets custom validation rules for the value of the filter.
+     * Replaces the rules inferred from the filter type.
+     *
+     * @param ValidationRule $rules
+     */
+    public function withValidation(array $rules): static
+    {
+        $this->validation['value'] = $rules;
+
+        return $this;
+    }
+
+    /**
+     * Adds custom validation rules for a sub-key of the value of the filter.
+     * Mostly useful for array filters, using `*` as the sub-key.
+     *
+     * @param ValidationRule $rules
+     */
+    public function addedValidation(string $subKey, array $rules): static
+    {
+        $this->validation['value.'.$subKey] = $rules;
 
         return $this;
     }
@@ -173,15 +203,18 @@ class Filter implements QueryFilter
     }
 
     /**
-     * @return array<string, array<int,string|Stringable|ValidationRule>> the validation rules for the filter
+     * @return ValidationRules the validation rules for the filter
      */
     #[Override]
     public function getValidation(): array
     {
         return [
-            'value' => ['nullable', ...$this->getType()->getValueValidation()],
-            'not' => ['boolean'],
-            'mode' => [Rule::in($this->getType()->getModes(), false)],
+            ...[
+                'value' => ['nullable', ...$this->getType()->getValueValidation()],
+                'not' => ['boolean'],
+                'mode' => [Rule::in($this->getType()->getModes(), false)],
+            ],
+            ...$this->validation,
         ];
     }
 

--- a/tests/Feature/FilterValidationQueryTest.php
+++ b/tests/Feature/FilterValidationQueryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\HttpQueryConfig\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sylarele\HttpQueryConfig\Enums\FilterMode;
+use Sylarele\HttpQueryConfig\Http\QueryRequest;
+use Sylarele\HttpQueryConfig\Query\Filter;
+use Sylarele\HttpQueryConfig\Tests\TestCase;
+use Workbench\App\Enums\FooState;
+use Workbench\Database\Factories\FooFactory;
+
+/**
+ * @internal
+ */
+#[CoversClass(Filter::class)]
+#[CoversClass(QueryRequest::class)]
+final class FilterValidationQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testShouldAcceptAValidValue(): void
+    {
+        $this->createFoos();
+
+        $this
+            ->getJson(
+                route(
+                    'foos.index',
+                    [
+                        'state[value]' => FooState::Pending->value,
+                        'state[mode]' => FilterMode::Equals->value,
+                    ]
+                )
+            )
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Alice');
+    }
+
+    public function testShouldRejectAnInvalidValue(): void
+    {
+        $this
+            ->getJson(
+                route(
+                    'foos.index',
+                    ['state[value]' => 'unknown']
+                )
+            )
+            ->assertUnprocessable()
+            ->assertJsonPath(
+                'errors',
+                ['state.value' => ['The selected state.value is invalid.']]
+            );
+    }
+
+    public function testShouldAcceptValidArrayValues(): void
+    {
+        $this->createFoos();
+
+        $this
+            ->getJson(
+                route(
+                    'foos.index',
+                    ['states[value]' => [FooState::Pending->value, FooState::Inactive->value]]
+                )
+            )
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function testShouldRejectInvalidArrayValues(): void
+    {
+        $this
+            ->getJson(
+                route(
+                    'foos.index',
+                    ['states[value]' => ['unknown']]
+                )
+            )
+            ->assertUnprocessable()
+            ->assertJsonPath(
+                'errors',
+                ['states.value.0' => ['The selected states.value.0 is invalid.']]
+            );
+    }
+
+    private function createFoos(): void
+    {
+        FooFactory::new()
+            ->createMany([
+                ['name' => 'Carol', 'state' => FooState::Active],
+                ['name' => 'Alice', 'state' => FooState::Pending],
+                ['name' => 'Eve', 'state' => FooState::Inactive],
+            ]);
+    }
+}

--- a/tests/Unit/FilterValidationTest.php
+++ b/tests/Unit/FilterValidationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylarele\HttpQueryConfig\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sylarele\HttpQueryConfig\Enums\FilterType;
+use Sylarele\HttpQueryConfig\Query\Filter;
+use Sylarele\HttpQueryConfig\Tests\TestCase;
+use Workbench\App\Builders\FooBuilder;
+use Workbench\App\Models\Foo;
+
+/**
+ * @internal
+ */
+#[CoversClass(Filter::class)]
+final class FilterValidationTest extends TestCase
+{
+    public function testShouldUseTheTypeValidationByDefault(): void
+    {
+        $filter = $this->makeFilter();
+
+        self::assertSame(
+            ['nullable', 'string', 'max:256'],
+            $filter->getValidation()['value']
+        );
+    }
+
+    public function testShouldReplaceTheTypeValidation(): void
+    {
+        $filter = $this->makeFilter()
+            ->withValidation(['required', 'string', 'max:10']);
+
+        $validation = $filter->getValidation();
+
+        self::assertSame(['required', 'string', 'max:10'], $validation['value']);
+        self::assertArrayHasKey('not', $validation);
+        self::assertArrayHasKey('mode', $validation);
+    }
+
+    public function testShouldAddValidationOnASubKeyOfTheValue(): void
+    {
+        $filter = $this->makeFilter()
+            ->type(FilterType::Array)
+            ->addedValidation('*', ['required', 'string']);
+
+        $validation = $filter->getValidation();
+
+        self::assertSame(['nullable', 'array'], $validation['value']);
+        self::assertSame(['required', 'string'], $validation['value.*']);
+    }
+
+    /**
+     * @return Filter<Foo,FooBuilder>
+     */
+    private function makeFilter(): Filter
+    {
+        /** @var Filter<Foo,FooBuilder> $filter */
+        $filter = new Filter(
+            model: new Foo(),
+            name: 'state',
+            mutate: static fn (): null => null,
+        );
+
+        return $filter->type(FilterType::String);
+    }
+}

--- a/workbench/app/Queries/FooQuery.php
+++ b/workbench/app/Queries/FooQuery.php
@@ -38,6 +38,17 @@ class FooQuery extends Query
         $config->filter('name')->type(FilterType::String);
         $config->filter('size')->type(FilterType::Integer);
 
+        // Filters with custom validation rules
+        $config
+            ->filter('state')
+            ->type(FilterType::String)
+            ->withValidation(['nullable', 'string', new Enum(FooState::class)]);
+        $config
+            ->filter('states')
+            ->field('state')
+            ->type(FilterType::Array)
+            ->addedValidation('*', ['required', 'string', new Enum(FooState::class)]);
+
         // Scopes
         $config
             ->filter('whereState')


### PR DESCRIPTION
Closes #54

## Problem

Validation for scalar filters was handled at the form request level, so every form request using a scalar filter had to implement its own rules — duplicated effort, and validation coupled to the wrong layer.

## Solution

Scalar filters declare their own rules in the query config, mirroring the API already available on `ScopeArgument`:

- `withValidation(array $rules)` — replaces the rules inferred from the `FilterType` for the `value` key (`state[value]`)
- `addedValidation(string $subKey, array $rules)` — adds rules on a sub-key of the value (`states[value][*]`)

Rules for the `mode` and `not` keys stay inferred from the `FilterType`.

```php
protected function configure(QueryConfig $config): void
{
    $config
        ->filter('state')
        ->type(FilterType::String)
        ->withValidation(['nullable', 'string', new Enum(FooState::class)]);

    $config
        ->filter('states')
        ->field('state')
        ->type(FilterType::Array)
        ->addedValidation('*', ['required', 'string', new Enum(FooState::class)]);
}
```

## Changes

- `Filter::withValidation()` / `Filter::addedValidation()`, merged over the type-derived rules in `Filter::getValidation()`
- Workbench `FooQuery` exercises both, end-to-end through the HTTP request
- Feature tests (accept/reject, scalar and array) and unit tests (default rules, replacement, sub-key)
- README section documenting the feature

## Checks

- `phpunit`: 63 tests, 189 assertions, OK
- `phpstan` (level max): no errors
- `php-cs-fixer`: 0 fixable
- `structura`: 47 passed
- `composer-dependency-analyser`: clean
- `rector`: fails on `Undefined constant Rector\PHPUnit\Set\PHPUnitSetList::COMPOSER_BASED` — pre-existing on `master`, unrelated to this change